### PR TITLE
Fix potential undefined issue with IP extraction in the ips function

### DIFF
--- a/api/rate-limit.ts
+++ b/api/rate-limit.ts
@@ -91,7 +91,7 @@ export default async function handler(request: any, response: any) {
     return request.status(500).json({error: "reCAPTCHA secret key not set"});
   }
   console.log(`keys exist`);
-  const ip = ips(request) ?? "127.0.0.1";
+  const ip = ips(request)?.[0] ?? "127.0.0.1";
 
   // const score = await createAssessment("movement-faucet-1722352143785", "6LdVjR0qAAAAAFSjzYqyRFsnUDn-iRrzQmv0nnp3", "", token);
   // console.log('score', score)


### PR DESCRIPTION
In the current implementation, the ips(request) function can potentially return undefined, which leads to issues when accessing ip[0]. This would result in unintended behavior if ips(request) does not return an array, as the ip[0] expression would then return the first character of the fallback string "127.0.0.1".

To address this, I've updated the code to safely access the first element of the array returned by ips(request) using optional chaining (?.[0]). This ensures that if ips(request) returns undefined or an empty array, the default value "127.0.0.1" is correctly assigned.

Changes:

Replaced const ip = ips(request) ?? "127.0.0.1"; with const ip = ips(request)?.[0] ?? "127.0.0.1"; to prevent potential errors and ensure proper fallback behavior.
Benefits:

This change eliminates the risk of unexpected behavior if ips(request) returns undefined.
Ensures that ip[0] correctly retrieves the IP address or falls back to "127.0.0.1" as intended.
